### PR TITLE
Load from bug fix with qos ue mobility

### DIFF
--- a/EventSubscription/src/main/java/com/nwdaf/Analytics/Controller/Nnwdaf_Controller.java
+++ b/EventSubscription/src/main/java/com/nwdaf/Analytics/Controller/Nnwdaf_Controller.java
@@ -32,8 +32,8 @@ public class Nnwdaf_Controller {
 
     private final Nnwdaf_Service nwdaf_service;
 
-    final String EVENT_SUB = "apiRoot/nnwdaf-eventssubscription/v1";
-    final String ANALYTICS ="apiRoot/nnwdaf-analyticsinfo/v1/analytics";
+    final String EVENT_SUB = "/nnwdaf-eventssubscription/v1";
+    final String ANALYTICS ="/nnwdaf-analyticsinfo/v1/analytics";
 
 
     @Autowired

--- a/EventSubscription/src/main/java/com/nwdaf/Analytics/Controller/Nnwdaf_Controller.java
+++ b/EventSubscription/src/main/java/com/nwdaf/Analytics/Controller/Nnwdaf_Controller.java
@@ -160,6 +160,7 @@ public class Nnwdaf_Controller {
 
         nwdaf_service.notificationHandler(response, EventID.LOAD_LEVEL_INFORMATION);
 
+
     }
 
 

--- a/EventSubscription/src/main/java/com/nwdaf/Analytics/Controller/Nnwdaf_Controller.java
+++ b/EventSubscription/src/main/java/com/nwdaf/Analytics/Controller/Nnwdaf_Controller.java
@@ -32,8 +32,8 @@ public class Nnwdaf_Controller {
 
     private final Nnwdaf_Service nwdaf_service;
 
-    final String EVENT_SUB = "/nnwdaf-eventssubscription/v1";
-    final String ANALYTICS ="/apiroot/nnwdaf-analyticsinfo/v1";
+    final String EVENT_SUB = "apiRoot/nnwdaf-eventssubscription/v1";
+    final String ANALYTICS ="apiRoot/nnwdaf-analyticsinfo/v1/analytics";
 
 
     @Autowired
@@ -174,7 +174,7 @@ public class Nnwdaf_Controller {
 
 
     // Accepting Notification UE-Mobility [ from Simulator]
-    @RequestMapping(method = RequestMethod.POST, value = "/Namf_EventExposure_Notify/{correlationID}")
+    @RequestMapping(method = RequestMethod.POST, value = "/Namf_Event_Exposure_Notify/{correlationID}")
     public void acceptingNotificationFromUEMobility(@RequestBody String response) throws Exception {
 
 

--- a/EventSubscription/src/main/java/com/nwdaf/Analytics/Model/TableType/UEMobility/UserLocation.java
+++ b/EventSubscription/src/main/java/com/nwdaf/Analytics/Model/TableType/UEMobility/UserLocation.java
@@ -11,26 +11,25 @@ public class UserLocation {
     private String cellID;
     private Integer timeDuration;
 
-    @Override
-    public String toString() {
-        return "UserLocation{" +
-                "ID=" + ID +
-                ", tai='" + tai + '\'' +
-                ", cellID='" + cellID + '\'' +
-                ", timeDuration=" + timeDuration +
-                '}';
-    }
+//    @Override
+//    public String toString() {
+//        return "UserLocation{" +
+//                "ID=" + ID +
+//                ", tai='" + tai + '\'' +
+//                ", cellID='" + cellID + '\'' +
+//                ", timeDuration=" + timeDuration +
+//                '}';
+//    }
 
     public UserLocation() {
     }
+//    public int getID() {
+//        return ID;
+//    }
 
-    public int getID() {
-        return ID;
-    }
-
-    public void setID(int ID) {
-        this.ID = ID;
-    }
+//    public void setID(int ID) {
+//        this.ID = ID;
+//    }
 
     public String getTai() {
         return tai;

--- a/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/BusinessLogic.java
+++ b/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/BusinessLogic.java
@@ -989,7 +989,8 @@ public class BusinessLogic extends ResourceValues {
                 repository.add_data_into_nwdafUEmobility(ueMobilitySubscriptionModel);
 
                 EventConnectionUE eventConnectionUE = new EventConnectionUE();
-                eventConnectionUE.setMessage("Data not Found for " + nnwdafEventsSubscriptionUE.getSupi());
+               // eventConnectionUE.setMessage("Data not Found for " + nnwdafEventsSubscriptionUE.getSupi());
+                eventConnectionUE.setMessage("204 No Content");
                 eventConnectionUE.setSupi(nnwdafEventsSubscriptionUE.getSupi());
                 eventConnectionUE.setDataStatus(false);
 

--- a/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/BusinessLogic.java
+++ b/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/BusinessLogic.java
@@ -568,6 +568,7 @@ public class BusinessLogic extends ResourceValues {
             json.put("QosSustainabilityInfo", qosInfo);
         }
 
+
         /**************************************************************************************************************/
 
 
@@ -919,38 +920,42 @@ public class BusinessLogic extends ResourceValues {
 
             out.println("\n\nSubscriptionListsize" + subscriptionDataList.size());
 
+            if (0 == subscriptionDataList.size()) {
+                out.println("NO_subscription found");
+            } else {
+                for (int k = 0; k < subscriptionDataList.size(); k++) {
+                    out.println("\nsubscriptionID_VIA_supi " + subscriptionDataList.get(k));
+                    SubscriptionTable subscriptionData = repository.findById_subscriptionID(subscriptionDataList.get(k));
 
-            for (int k = 0; k < subscriptionDataList.size(); k++) {
-                out.println("\nsubscriptionID_VIA_supi " + subscriptionDataList.get(k));
-                SubscriptionTable subscriptionData = repository.findById_subscriptionID(subscriptionDataList.get(k));
+                    //out.println("\nEventID " + subscriptionData.getEventID() +
+                    //  "\nSubscriptionID - "+ subscriptionData.getSubscriptionID());
 
-                //out.println("\nEventID " + subscriptionData.getEventID() +
-                //  "\nSubscriptionID - "+ subscriptionData.getSubscriptionID());
-
-                out.println("\nnotificaitonURI - " + subscriptionData.getNotificationURI() +
-                        "\neventID - " + EventID.values()[subscriptionData.getEventID()].toString() +
-                        "\nsupi - " + supiList.get(i).getSupi() +
-                        "\nTai value - " + userLocation.getTai() +
-                        "\nSubscriptionID - " + subscriptionData.getSubscriptionID());
-
-
-                if (!subID_SET.contains(subscriptionDataList.get(k))) {
-                    subID_SET.add(subscriptionDataList.get(k));
-
-                    // send_notificaiton_to_NF_forUEMobility(subscriptionData.getNotificationURI(),
-                    //       EventID.values()[subscriptionData.getEventID()].toString());
+                    out.println("\nnotificaitonURI - " + subscriptionData.getNotificationURI() +
+                            "\neventID - " + EventID.values()[subscriptionData.getEventID()].toString() +
+                            "\nsupi - " + supiList.get(i).getSupi() +
+                            "\nTai value - " + userLocation.getTai() +
+                            "\nSubscriptionID - " + subscriptionData.getSubscriptionID());
 
 
-                    send_notificaiton_to_NF(subscriptionData.getNotificationURI(),
-                            EventID.values()[subscriptionData.getEventID()].toString(),
-                            "null",
+                    if (!subID_SET.contains(subscriptionDataList.get(k))) {
+                        subID_SET.add(subscriptionDataList.get(k));
 
-                            userLocations,
-                            supiList.get(i).getSupi(),
-                            0, subscriptionData.getSubscriptionID());
+                        // send_notificaiton_to_NF_forUEMobility(subscriptionData.getNotificationURI(),
+                        //       EventID.values()[subscriptionData.getEventID()].toString());
+
+
+                        send_notificaiton_to_NF(subscriptionData.getNotificationURI(),
+                                EventID.values()[subscriptionData.getEventID()].toString(),
+                                "null",
+
+                                userLocations,
+                                supiList.get(i).getSupi(),
+                                0, subscriptionData.getSubscriptionID());
+                    }
+
                 }
-
             }
+
 
         }
     }
@@ -1186,11 +1191,24 @@ public class BusinessLogic extends ResourceValues {
         sliceLoadLevelInfo.put("loadLevelInformation", currentLoadLevel);
         sliceLoadLevelInfo.put("snssais", snssaisArray);
 
-        eventNotificationObject.put("NwdafEvent", eventID);
-        eventNotificationObject.put("SliceLoadLevelInformation", sliceLoadLevelInfo);
-        eventNotificationObject.put("ueMobs", uEMobilityArray);
+        /*FIXED JSON PAYLOAD
+         * It will only send data for particular event-ID*/
 
-        eventNotificationArray.put(eventNotificationObject);
+        if (eventID == "LOAD_LEVEL_INFORMATION") {
+            eventNotificationObject.put("NwdafEvent", eventID);
+            eventNotificationObject.put("SliceLoadLevelInformation", sliceLoadLevelInfo);
+            eventNotificationArray.put(eventNotificationObject);
+        }
+        if (eventID == "UE_MOBILITY") {
+            eventNotificationObject.put("NwdafEvent", eventID);
+            eventNotificationObject.put("ueMobs", uEMobilityArray);
+            eventNotificationArray.put(eventNotificationObject);
+        }
+
+        if (eventID == "QOS_SUSTAINABILITY") {
+            /*add Qos Here*/
+        }
+
 
         eventNotificationFinalObject.put("eventNotifications", eventNotificationArray);
         eventNotificationFinalObject.put("subscriptionId", subscriptionID);
@@ -1486,9 +1504,9 @@ public class BusinessLogic extends ResourceValues {
                 con.setRequestProperty("Accept", "application/json");
 
                 // Function To Send CorrelationID to SIMULATOR
-              //  int responseCode = send_data_receieve_response(nnrfModel, con);
+                //  int responseCode = send_data_receieve_response(nnrfModel, con);
 
-                int responseCode = send_data_receieve_response_AMF(amfModel,con);
+                int responseCode = send_data_receieve_response_AMF(amfModel, con);
 
                 if (responseCode != HttpStatus.OK.value()) {
                     throw new Exception();

--- a/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/BusinessLogic.java
+++ b/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/BusinessLogic.java
@@ -63,7 +63,6 @@ public class BusinessLogic extends ResourceValues {
     UserLocation userLocation = new UserLocation();
 
 
-
     /**
      * @param nnwdafEventsSubscription
      * @throws IOException
@@ -94,8 +93,7 @@ public class BusinessLogic extends ResourceValues {
                 }
 
 
-                if(eventID == EventID.LOAD_LEVEL_INFORMATION.ordinal())
-                {
+                if (eventID == EventID.LOAD_LEVEL_INFORMATION.ordinal()) {
                     // Adding snssais into database
                     repository.add_data_into_load_level_table(nnwdafEventsSubscription.getSnssais());
 
@@ -111,18 +109,15 @@ public class BusinessLogic extends ResourceValues {
 
                     //throw new NullPointerException("Data not found!");
                     return eventConnection;
-                }
-
-                else if(eventID == EventID.QOS_SUSTAINABILITY.ordinal())
-                {
+                } else if (eventID == EventID.QOS_SUSTAINABILITY.ordinal()) {
                     repository.setNwdafQosSustainabilityInformation(nnwdafEventsSubscription.getSnssais());
 
                     QosAnalyticsInfo qosInfo = new QosAnalyticsInfo(nnwdafEventsSubscription.getSnssais(), HttpStatus.NOT_FOUND);
 
                     logger.debug("eventID: " + EventID.QOS_SUSTAINABILITY.toString() + "\n" +
                             "snssais: " + nnwdafEventsSubscription.getSnssais() + "\n" +
-                            " ranUeThroughput: " + qosInfo.getRanUeThroughput()  + "\n" +
-                            " qosFlowRetain: " + qosInfo.getQosFlowRetain()  + "\n" +
+                            " ranUeThroughput: " + qosInfo.getRanUeThroughput() + "\n" +
+                            " qosFlowRetain: " + qosInfo.getQosFlowRetain() + "\n" +
                             "DataStatus:  " + qosInfo.getDataStatus());
 
                     return qosInfo;
@@ -188,7 +183,7 @@ public class BusinessLogic extends ResourceValues {
             // Updated URL For NWDAF to Subscribe
             // updated_POST_NRF_URL = POST_NRF_URL + "/" + correlationID;
             // POST_NRF_URL = NRF URL ------> [ Reading from ]application.properties
-           try {
+            try {
 
                 URL obj = new URL(POST_NRF_URL);
                 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
@@ -217,14 +212,14 @@ public class BusinessLogic extends ResourceValues {
 
             logger.debug(FrameWorkFunction.EXIT + FUNCTION_NAME);
             return correlationID;
-         }  else {
+        } else {
 
-            if(!getAnalytics)
-            { repository.increaseRefCount(nnwdafEventsSubscription.getSnssais(), EventID.values()[nnwdafEventsSubscription.getEventID()]); }
+            if (!getAnalytics) {
+                repository.increaseRefCount(nnwdafEventsSubscription.getSnssais(), EventID.values()[nnwdafEventsSubscription.getEventID()]);
+            }
         }
         return null;
     }
-
 
 
     /**
@@ -276,7 +271,7 @@ public class BusinessLogic extends ResourceValues {
 
 
         // notificationTargetUrl = Namf_EventExposure_Notify
-        json.put("notificationTargetAddress", notificationTargetUrl);
+        json.put("notificationTargetAddress", notificationTargetUrlForAMF);
 
         // For POST only - START
         con.setDoOutput(true);
@@ -327,8 +322,7 @@ public class BusinessLogic extends ResourceValues {
 
                 int eventID = nnwdafEventsSubscription.getEventID();
 
-                if(eventID == EventID.LOAD_LEVEL_INFORMATION.ordinal())
-                {
+                if (eventID == EventID.LOAD_LEVEL_INFORMATION.ordinal()) {
                     SliceLoadLevelSubscriptionTable slice = new SliceLoadLevelSubscriptionTable();
                     slice.setCorrelationID(String.valueOf(correlationID));
                     slice.setSubscriptionID(response.toString());
@@ -341,24 +335,20 @@ public class BusinessLogic extends ResourceValues {
                     } else {
                         repository.addCorrealationIDAndUnSubCorrelationIDIntoNwdafIDTable(slice, false);
                     }
-                }
-
-                else if(eventID == EventID.QOS_SUSTAINABILITY.ordinal())
-                {
+                } else if (eventID == EventID.QOS_SUSTAINABILITY.ordinal()) {
                     QosSustainabilitySubscriptionTable qos = new QosSustainabilitySubscriptionTable();
 
                     qos.setCorrelationID(String.valueOf(correlationID));
                     qos.setSubscriptionID(response.toString());
                     qos.setSnssais(nnwdafEventsSubscription.getSnssais());
 
-                    if(getAnalytics)
-                    {
-                        if(!repository.snsExists(qos.getSnssais(), EventID.QOS_SUSTAINABILITY))
-                        { repository.addDataQosSustainabilitySubscriptionTable(qos, true); }
+                    if (getAnalytics) {
+                        if (!repository.snsExists(qos.getSnssais(), EventID.QOS_SUSTAINABILITY)) {
+                            repository.addDataQosSustainabilitySubscriptionTable(qos, true);
+                        }
+                    } else {
+                        repository.addDataQosSustainabilitySubscriptionTable(qos, false);
                     }
-
-                    else
-                    { repository.addDataQosSustainabilitySubscriptionTable(qos, false); }
                 }
 
 
@@ -373,10 +363,6 @@ public class BusinessLogic extends ResourceValues {
 
         logger.debug(FrameWorkFunction.EXIT + FUNCTION_NAME);
     }
-
-
-
-
 
 
     /**
@@ -446,8 +432,8 @@ public class BusinessLogic extends ResourceValues {
                 "unSubCorrelationId", nnrfModel.getUnSubCorrelationId());
 
 
-        // notificationTargetUrl = Namf_EventExposure_Notify
-        json.put("notificationTargetAddress", notificationTargetUrl);
+        // notificationTargetUrl = NRF URL
+        json.put("notificationTargetAddress", notificationTargetUrlForNRF);
 
         // For POST only - START
         con.setDoOutput(true);
@@ -466,6 +452,7 @@ public class BusinessLogic extends ResourceValues {
         return responseCode;
 
     }
+
     /**
      * @param snssais
      * @return
@@ -488,15 +475,13 @@ public class BusinessLogic extends ResourceValues {
     }
 
 
-
     protected void send_notificaiton_to_NF(String notificationURI,
                                            EventID eventID,
                                            String snssais,
                                            Integer currentLoadLevel,
-                                           String subscriptionID) throws IOException, JSONException
-    { send_notificaiton_to_NF(notificationURI, eventID, snssais, currentLoadLevel, subscriptionID, null); }
-
-
+                                           String subscriptionID) throws IOException, JSONException {
+        send_notificaiton_to_NF(notificationURI, eventID, snssais, currentLoadLevel, subscriptionID, null);
+    }
 
 
     /**
@@ -516,21 +501,20 @@ public class BusinessLogic extends ResourceValues {
         Counters.incrementSubscriptionNotifications();
 
 
-
-       // URL url = null;
+        // URL url = null;
         //try {
-           URL url = new URL(notificationURI);
+        URL url = new URL(notificationURI);
         //} catch (MalformedURLException e) {
-           // logger.warn("http connect exception found");
-            //e.printStackTrace();
+        // logger.warn("http connect exception found");
+        //e.printStackTrace();
         //}
 
         // Opening connection;
-       // HttpURLConnection con = null;
+        // HttpURLConnection con = null;
         ///try {
-         HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
         //} catch (IOException e) {
-            //e.printStackTrace();
+        //e.printStackTrace();
 
         //}
 
@@ -549,8 +533,7 @@ public class BusinessLogic extends ResourceValues {
 
         json.put("eventID", eventID.toString());
 
-        if(eventID == EventID.LOAD_LEVEL_INFORMATION)
-        {
+        if (eventID == EventID.LOAD_LEVEL_INFORMATION) {
             json.put("snssais", snssais);
 
 
@@ -560,11 +543,7 @@ public class BusinessLogic extends ResourceValues {
 
 
             json.put("currentLoadLevel", currentLoadLevel);
-        }
-
-
-        else if(eventID == EventID.QOS_SUSTAINABILITY)
-        {
+        } else if (eventID == EventID.QOS_SUSTAINABILITY) {
 
             QosSustainabilityInfo qosSustainabilityInfo = repository.getPlmnID_Tac(subscriptionID, currentLoadLevel, qosType);
 
@@ -580,11 +559,11 @@ public class BusinessLogic extends ResourceValues {
 
             qosInfo.put("areaInfo", areaInfo);
 
-            if(qosType == QosType.RAN_UE_THROUGHPUT)
-            { qosInfo.put("crossedRanUeThroughputThreshold", currentLoadLevel); }
-
-            else
-            { qosInfo.put("crossedQosFlowRetainThreshold", currentLoadLevel); }
+            if (qosType == QosType.RAN_UE_THROUGHPUT) {
+                qosInfo.put("crossedRanUeThroughputThreshold", currentLoadLevel);
+            } else {
+                qosInfo.put("crossedQosFlowRetainThreshold", currentLoadLevel);
+            }
 
             json.put("QosSustainabilityInfo", qosInfo);
         }
@@ -614,10 +593,9 @@ public class BusinessLogic extends ResourceValues {
             e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();
+        } finally {
+            con.disconnect();
         }
-
-        finally
-        { con.disconnect(); }
 
         logger.debug(FrameWorkFunction.EXIT + FUNCTION_NAME);
 
@@ -638,16 +616,12 @@ public class BusinessLogic extends ResourceValues {
         String mCorrelationID = "";
         String correlationID = "";
 
-        if(eventID == EventID.LOAD_LEVEL_INFORMATION.ordinal())
-        {
+        if (eventID == EventID.LOAD_LEVEL_INFORMATION.ordinal()) {
             mCorrelationID = repository.getUnSubCorrelationID(snssais, EventID.LOAD_LEVEL_INFORMATION);
             //   String mCorrelationID = repository.getUnSubCorrelationID(snssais);
 
             correlationID = repository.getCorrelationID(mCorrelationID, EventID.LOAD_LEVEL_INFORMATION);
-        }
-
-        else if(eventID == EventID.QOS_SUSTAINABILITY.ordinal())
-        {
+        } else if (eventID == EventID.QOS_SUSTAINABILITY.ordinal()) {
             mCorrelationID = repository.getUnSubCorrelationID(snssais, EventID.QOS_SUSTAINABILITY);
             correlationID = repository.getCorrelationID(mCorrelationID, EventID.QOS_SUSTAINABILITY);
         }
@@ -686,15 +660,11 @@ public class BusinessLogic extends ResourceValues {
             e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();
+        } finally {
+            con.disconnect();
         }
 
-        finally
-        { con.disconnect(); }
-
     }
-
-
-
 
 
     protected boolean testConnection() {
@@ -709,14 +679,16 @@ public class BusinessLogic extends ResourceValues {
 
             if (con.getResponseCode() != HttpStatus.ACCEPTED.value()) {
 
-                if(con != null)
-                { con.disconnect(); }
+                if (con != null) {
+                    con.disconnect();
+                }
 
                 return false;
             }
 
-            if(con != null)
-            { con.disconnect(); }
+            if (con != null) {
+                con.disconnect();
+            }
 
         } catch (Exception ex) {
             return false;
@@ -724,7 +696,6 @@ public class BusinessLogic extends ResourceValues {
 
         return true;
     }
-
 
 
     // Updated nwdaf_notification_manager 3rd March, 2020
@@ -741,19 +712,15 @@ public class BusinessLogic extends ResourceValues {
             return;
         }
 
-        for(SliceLoadLevelInformation slice: list)
-        {
+        for (SliceLoadLevelInformation slice : list) {
             List<NotificationData> dataSet = repository.getAllNotificationData(slice.getSnssais(), slice.getCurrentLoadLevel());
 
-            if(dataSet != null && !dataSet.isEmpty())
-            {
-                for(NotificationData notifyData: dataSet)
-                {
-                    if(!subID_SET.contains(notifyData.getSubscriptionID()))
-                    {
+            if (dataSet != null && !dataSet.isEmpty()) {
+                for (NotificationData notifyData : dataSet) {
+                    if (!subID_SET.contains(notifyData.getSubscriptionID())) {
                         subID_SET.add(notifyData.getSubscriptionID());
 
-                       //SubscriptionTable subscriptionData = repository.findById_subscriptionID(notifyData.getSubscriptionID());
+                        //SubscriptionTable subscriptionData = repository.findById_subscriptionID(notifyData.getSubscriptionID());
                         send_notificaiton_to_NF(repository.getNotificationURI(notifyData.getSubscriptionID()), EventID.LOAD_LEVEL_INFORMATION, slice.getSnssais(), slice.getCurrentLoadLevel(), notifyData.getSubscriptionID());
                     }
 
@@ -764,9 +731,6 @@ public class BusinessLogic extends ResourceValues {
 
         logger.debug(FrameWorkFunction.EXIT + FUNCTION_NAME);
     }
-
-
-
 
 
     protected void qosNotificationManager(QosType qosType) throws IOException, JSONException {
@@ -782,29 +746,25 @@ public class BusinessLogic extends ResourceValues {
             return;
         }
 
-        for(QosSustainabilityInformation qos: list)
-        {
+        for (QosSustainabilityInformation qos : list) {
             List<QosNotificationData> dataSet;
 
-            if(qosType == QosType.RAN_UE_THROUGHPUT)
-            { dataSet = repository.getAllQosNotificationData(qos.getSnssais(), qos.getRanUeThroughput() ,qosType); }
+            if (qosType == QosType.RAN_UE_THROUGHPUT) {
+                dataSet = repository.getAllQosNotificationData(qos.getSnssais(), qos.getRanUeThroughput(), qosType);
+            } else {
+                dataSet = repository.getAllQosNotificationData(qos.getSnssais(), qos.getQosFlowRetain(), qosType);
+            }
 
-            else
-            { dataSet = repository.getAllQosNotificationData(qos.getSnssais(), qos.getQosFlowRetain() ,qosType); }
 
-
-            if(dataSet != null && !dataSet.isEmpty())
-            {
-                if(qosType == QosType.RAN_UE_THROUGHPUT)
-                {
-                    for(QosNotificationData notifyData: dataSet)
-                    { send_notificaiton_to_NF(repository.getNotificationURI(notifyData.getSubscriptionID()), EventID.QOS_SUSTAINABILITY, qos.getSnssais(), qos.getRanUeThroughput(), notifyData.getSubscriptionID(), QosType.RAN_UE_THROUGHPUT); }
-                }
-
-                else
-                {
-                    for(QosNotificationData notifyData: dataSet)
-                    { send_notificaiton_to_NF(repository.getNotificationURI(notifyData.getSubscriptionID()), EventID.QOS_SUSTAINABILITY, qos.getSnssais(), qos.getQosFlowRetain(), notifyData.getSubscriptionID(), QosType.QOS_FLOW_RETAIN); }
+            if (dataSet != null && !dataSet.isEmpty()) {
+                if (qosType == QosType.RAN_UE_THROUGHPUT) {
+                    for (QosNotificationData notifyData : dataSet) {
+                        send_notificaiton_to_NF(repository.getNotificationURI(notifyData.getSubscriptionID()), EventID.QOS_SUSTAINABILITY, qos.getSnssais(), qos.getRanUeThroughput(), notifyData.getSubscriptionID(), QosType.RAN_UE_THROUGHPUT);
+                    }
+                } else {
+                    for (QosNotificationData notifyData : dataSet) {
+                        send_notificaiton_to_NF(repository.getNotificationURI(notifyData.getSubscriptionID()), EventID.QOS_SUSTAINABILITY, qos.getSnssais(), qos.getQosFlowRetain(), notifyData.getSubscriptionID(), QosType.QOS_FLOW_RETAIN);
+                    }
                 }
             }
         }
@@ -813,16 +773,7 @@ public class BusinessLogic extends ResourceValues {
     }
 
 
-
-
-
-
     /**************************UE_MOBILITY code*********************************************************************/
-
-
-
-
-
 
 
     protected Object check_For_data_for_UE_Mobility(NnwdafEventsSubscription nnwdafEventsSubscription, boolean getAnalytics) throws IOException, JSONException {
@@ -902,13 +853,10 @@ public class BusinessLogic extends ResourceValues {
     }
 
 
-
-
     public void add_value_to_userLocationTable(String taiValue, String cellID, Integer timeDuration) {
 
         repository.addValuesToUserLocationTable(taiValue, cellID, timeDuration);
     }
-
 
 
     public void updateUEMobilityTable(String correlationID) {
@@ -922,9 +870,6 @@ public class BusinessLogic extends ResourceValues {
         //Updating the location of supi;
         repository.updateLocatoinValueToUEMobilityTable(IDs, supi);
     }
-
-
-
 
 
     protected void nwdaf_notification_manager_ForUEMobility() throws IOException, JSONException {
@@ -999,6 +944,7 @@ public class BusinessLogic extends ResourceValues {
                     send_notificaiton_to_NF(subscriptionData.getNotificationURI(),
                             EventID.values()[subscriptionData.getEventID()].toString(),
                             "null",
+
                             userLocations,
                             supiList.get(i).getSupi(),
                             0, subscriptionData.getSubscriptionID());
@@ -1008,8 +954,6 @@ public class BusinessLogic extends ResourceValues {
 
         }
     }
-
-
 
 
     protected Object check_For_dataUEmobility(NnwdafEventsSubscriptionUEmobility nnwdafEventsSubscriptionUE, boolean getAnalytics) throws IOException, JSONException {
@@ -1078,8 +1022,6 @@ public class BusinessLogic extends ResourceValues {
     }
 
 
-
-
     private Object nwdaf_data_collector_For_UE_Mobility(NnwdafEventsSubscription nnwdafEventsSubscription, boolean getAnalytics) {
 
         final String FUNCTION_NAME = Thread.currentThread().getStackTrace()[1].getMethodName() + "()";
@@ -1141,10 +1083,6 @@ public class BusinessLogic extends ResourceValues {
     }
 
 
-
-
-
-
     /**
      * @param notificationURI
      * @throws IOException
@@ -1179,7 +1117,6 @@ public class BusinessLogic extends ResourceValues {
 
         JSONArray ueTrajectoryArray = new JSONArray();
         JSONObject ueTrajectoryObject = new JSONObject();
-
 
 
         for (int i = 0; i < userLocations.size(); i++) {
@@ -1230,8 +1167,6 @@ public class BusinessLogic extends ResourceValues {
             locationInfoArray.put(locationInfoObject);
 
         }
-
-
 
 
         ueTrajectoryObject.put("ts", "Date-time-value");
@@ -1455,8 +1390,6 @@ public class BusinessLogic extends ResourceValues {
     }
 
 
-
-
     public List<EventConnectionForUEMobility> getUElocation(String supi) {
 
 
@@ -1520,7 +1453,6 @@ public class BusinessLogic extends ResourceValues {
     }
 
 
-
     protected Object nwdaf_data_collectorUEmobility(NnwdafEventsSubscriptionUEmobility nnwdafEventsSubscriptionUE, boolean getAnalytics) throws IOException, JSONException {
 
         final String FUNCTION_NAME = Thread.currentThread().getStackTrace()[1].getMethodName() + "()";
@@ -1534,10 +1466,11 @@ public class BusinessLogic extends ResourceValues {
             UUID correlationID = FrameWorkFunction.getUniqueID();
 
 
-            Nnrf_Model nnrfModel = new Nnrf_Model();
+            //  Nnrf_Model nnrfModel = new Nnrf_Model();
 
+            AMFModel amfModel = new AMFModel();
             // Adding correlationID to object and send to SIMULATOR
-            nnrfModel.setCorrelationId(String.valueOf(correlationID));
+            amfModel.setCorrelationId(String.valueOf(correlationID));
             // Updated URL For NWDAF to Subscribe
             // updated_POST_NRF_URL = POST_NRF_URL + "/" + correlationID;
             // POST_NRF_URL = NRF URL ------> [ Reading from ]application.properties
@@ -1553,7 +1486,9 @@ public class BusinessLogic extends ResourceValues {
                 con.setRequestProperty("Accept", "application/json");
 
                 // Function To Send CorrelationID to SIMULATOR
-                int responseCode = send_data_receieve_response(nnrfModel, con);
+              //  int responseCode = send_data_receieve_response(nnrfModel, con);
+
+                int responseCode = send_data_receieve_response_AMF(amfModel,con);
 
                 if (responseCode != HttpStatus.OK.value()) {
                     throw new Exception();
@@ -1581,8 +1516,6 @@ public class BusinessLogic extends ResourceValues {
     }
 
 
-
-
     private int send_data_receieve_response_For_UEMobility(AMFModel amfModel, HttpURLConnection con) throws JSONException, IOException {
 
         JSONObject json = new JSONObject();
@@ -1592,7 +1525,7 @@ public class BusinessLogic extends ResourceValues {
 
 
         // notificationTargetUrl = Namf_EventExposure_Notify
-        json.put("notificationTargetAddress", notificationTargetUrl);
+        json.put("notificationTargetAddress", notificationTargetUrlForAMF);
 
         // For POST only - START
         con.setDoOutput(true);
@@ -1610,8 +1543,6 @@ public class BusinessLogic extends ResourceValues {
 
         return responseCode;
     }
-
-
 
 
     private void response_handler_for_UEMobility(NnwdafEventsSubscription nnwdafEventsSubscription, int responseCode, UUID correlationID, HttpURLConnection con, boolean getAnalytics) throws IOException {
@@ -1664,8 +1595,6 @@ public class BusinessLogic extends ResourceValues {
     }
 
 
-
-
     protected void response_handlerUEmobility(NnwdafEventsSubscriptionUEmobility nnwdafEventsSubscriptionUE,
                                               int responseCode, UUID correlationID,
                                               HttpURLConnection con, boolean getAnalytics) throws IOException {
@@ -1713,7 +1642,6 @@ public class BusinessLogic extends ResourceValues {
 
         logger.debug(FrameWorkFunction.EXIT + FUNCTION_NAME);
     }
-
 
 
     /************************************************************************************************************************/

--- a/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/Nnwdaf_Service.java
+++ b/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/Nnwdaf_Service.java
@@ -587,6 +587,7 @@ public class Nnwdaf_Service extends BusinessLogic {
             repository.deleteEntry_UEMobilitySubscriptionTable(supi);
         }
 
+       // repository.getRefCount_UEmobilitySubscriptionTable()
         nwdaf_notification_manager_ForUEMobility();
 
     }

--- a/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/ResourceValues.java
+++ b/EventSubscription/src/main/java/com/nwdaf/Analytics/Service/ResourceValues.java
@@ -8,7 +8,10 @@ public class ResourceValues {
     String URI;
 
     @Value("${spring.NRF_NotificationTarget.Url}")
-    String notificationTargetUrl;
+    String notificationTargetUrlForNRF;
+
+    @Value("${spring.AMF_NotificationTarget.Url}")
+    String notificationTargetUrlForAMF;
 
     @Value("${spring.Simulator.testConnection}")
     String testConnect_URI;

--- a/EventSubscription/src/main/resources/application.properties
+++ b/EventSubscription/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 server.port=8081
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/NWDAF
-spring.datasource.username=
-spring.datasource.password=
+spring.datasource.username=springuser
+spring.datasource.password=ThePassword
 
 
 
@@ -35,3 +35,9 @@ spring.NRF_NotificationTarget.Url = ${spring.NRF_NotificationTarget.header}${spr
 spring.AMF.Subscribe.url = ${spring.Simulator.header}${spring.Simulator.IP.Address}${spring.Simulator.port}/Namf_Event_Exposure_Subscribe
 spring.AMF.UnSubscribe.url = ${spring.Simulator.header}${spring.Simulator.IP.Address}${spring.Simulator.port}/Namf_Event_Exposure_UnSubscribe
 spring.AMF_NOTIFICATION.url = http://localhost:8081/Namf_Event_Exposure_Notify
+
+
+spring.AMF_NotificationTarget.header = http://
+spring.AMF_NotificationTarget.IP.Address = localhost:
+spring.AMF_NotificationTarget.Port = 8081
+spring.AMF_NotificationTarget.Url = ${spring.AMF_NotificationTarget.header}${spring.AMF_NotificationTarget.IP.Address}${spring.AMF_NotificationTarget.Port}/Namf_Event_Exposure_Notify

--- a/Simulator/AMF/src/main/java/com/nwdaf/AMF/AMFController.java
+++ b/Simulator/AMF/src/main/java/com/nwdaf/AMF/AMFController.java
@@ -32,6 +32,11 @@ public class AMFController extends Functionality {
     Random rand = new Random();
 
     public static List<String> correlationIDList = new ArrayList<>();
+    public static List<String> correlationIDListForUE = new ArrayList<>();
+
+    public static List<String> getCorrelationIDListForUE() {
+        return correlationIDListForUE;
+    }
 
     public List<String> getCorrelationIDList() {
         return correlationIDList;
@@ -40,7 +45,7 @@ public class AMFController extends Functionality {
 
     @GetMapping("/sendDataToUEMobility/{correlationID}")
     public void sendUEData(@PathVariable String correlationID) throws IOException, JSONException {
-        for (int i = 0; i < correlationIDList.size(); i++) {
+        for (int i = 0; i < correlationIDListForUE.size(); i++) {
             // sendDataForUEMobility("http://localhost:8081/Namf_EventExposure_Notify",
             //       correlationIDList.get(i));
 
@@ -84,7 +89,7 @@ public class AMFController extends Functionality {
         //  out.println("subListSize - " + AmfApplication.getSubIDList().size());
 
         // Stirn
-        Integer size= AmfApplication.getUnSubURIMap().size();
+        Integer size = AmfApplication.getUnSubURIMap().size();
         // out.println("size of map " + size);
 
 
@@ -97,7 +102,8 @@ public class AMFController extends Functionality {
                 String UnSubURI = entry.getValue() + entry.getKey();
                 out.println("Un-SubURI - - - > " + UnSubURI);
 
-                unsubscribe(entry.getValue().trim(),entry.getKey().trim());
+//                unsubscribe(entry.getValue().trim(), entry.getKey().trim());
+                //              AmfApplication.getUnSubURIMap().remove(entry);
             }
 //            System.out.println("Key = " + entry.getKey() +
 //                    ", Value = " + entry.getValue());
@@ -134,7 +140,7 @@ public class AMFController extends Functionality {
         return new ResponseEntity<String>("unSubscribed", HttpStatus.OK);
     }
 
-
+    /*UE-Mobility*/
 
     @RequestMapping(method = RequestMethod.DELETE, value = "/Namf_Event_Exposure_UnSubscribe")
     public ResponseEntity<String> unsubScribeFromNWDAFForUEMobility(@RequestBody String response) throws JSONException, IOException {
@@ -143,13 +149,15 @@ public class AMFController extends Functionality {
         String unSubCorrelationID = jsonObject.getString("mSubcorrelationID");
         String correlationID = jsonObject.getString("correlationID");
 
-        correlationIDList.remove(correlationID);
+        correlationIDListForUE.remove(correlationID);
         // list.delete();
         //     out.println("Unsubscribed from NWDAF WORKED for " + response);
 
 
         return new ResponseEntity<String>("unSubscribed", HttpStatus.OK);
     }
+
+    /*UE-Mobility*/
 
 
  /*   @RequestMapping(method = RequestMethod.DELETE, value = "/Nnrf_NFManagement_NFStatusUnSubscribe")
@@ -180,12 +188,11 @@ public class AMFController extends Functionality {
 
         // Adding unSubCorrelationId into database;
         UUID unSubCorrelationId = UUID.randomUUID();
-        out.println("in-load-level----->> + "+obj.getNotificationTargetAddress() + "::"+obj.getCorrelationId());
+        out.println("in-load-level----->> + " + obj.getNotificationTargetAddress() + "::" + obj.getCorrelationId());
         correlationIDList.add(obj.getCorrelationId());
 
         return new ResponseEntity<String>(String.valueOf(unSubCorrelationId), HttpStatus.OK);
     }
-
 
 
     @RequestMapping(method = RequestMethod.POST, value = "/Namf_Event_Exposure_Subscribe")
@@ -202,9 +209,9 @@ public class AMFController extends Functionality {
         // Adding unSubCorrelationId into database;
         UUID unSubCorrelationId = UUID.randomUUID();
 
-        out.println("in-UE-Mobility----->> + "+obj.getNotificationTargetAddress() + "::"+obj.getCorrelationId());
+        out.println("in-UE-Mobility----->> + " + obj.getNotificationTargetAddress() + "::" + obj.getCorrelationId());
 
-        correlationIDList.add(obj.getCorrelationId());
+        correlationIDListForUE.add(obj.getCorrelationId());
 
         return new ResponseEntity<String>(String.valueOf(unSubCorrelationId), HttpStatus.OK);
     }
@@ -299,14 +306,10 @@ public class AMFController extends Functionality {
     }
 
 
-
     //  @Override
     //public void getCorrelationList(List<String> correlationList) {
     //  out.println(correlationList.size());
     // }
-
-
-
 
 
     @PostMapping("/update/{qosLoadType}/{correlationID}")
@@ -344,14 +347,13 @@ public class AMFController extends Functionality {
 
         loadType = loadType.toLowerCase();
 
-        if(loadType.equals(ranUeThroughput))
-        { json.put("ranUeThroughput", 1 + rand.nextInt(85)); }
-
-        else if(loadType.equals(qosFlowRetain))
-        { json.put("qosFlowRetain", 1 + rand.nextInt(85)); }
-
-        else
-        { return new ResponseEntity<String>("Invalid load value", HttpStatus.NOT_ACCEPTABLE); }
+        if (loadType.equals(ranUeThroughput)) {
+            json.put("ranUeThroughput", 1 + rand.nextInt(85));
+        } else if (loadType.equals(qosFlowRetain)) {
+            json.put("qosFlowRetain", 1 + rand.nextInt(85));
+        } else {
+            return new ResponseEntity<String>("Invalid load value", HttpStatus.NOT_ACCEPTABLE);
+        }
 
         json.put("correlationID", correlationID);
 
@@ -397,14 +399,12 @@ public class AMFController extends Functionality {
         }
         //  return "Data send to " + updated_URL;
 
-        if(con != null)
-        { con.disconnect(); }
+        if (con != null) {
+            con.disconnect();
+        }
 
         return new ResponseEntity<String>("Send", HttpStatus.OK);
     }
-
-
-
 
 
     public ResponseEntity<String> sendDataForUEMobility(String notiTargetAddress,
@@ -528,8 +528,6 @@ public class AMFController extends Functionality {
         // return new ResponseEntity<String>(USER_LOCATION_ARRAY.toString(), HttpStatus.OK);
         return new ResponseEntity<>("Created", HttpStatus.OK);
     }
-
-
 
 
     public void testJSONData() throws JSONException {

--- a/Simulator/AMF/src/main/java/com/nwdaf/AMF/AMFController.java
+++ b/Simulator/AMF/src/main/java/com/nwdaf/AMF/AMFController.java
@@ -44,7 +44,7 @@ public class AMFController extends Functionality {
             // sendDataForUEMobility("http://localhost:8081/Namf_EventExposure_Notify",
             //       correlationIDList.get(i));
 
-            sendDataForUEMobility("http://localhost:8081/Namf_EventExposure_Notify",
+            sendDataForUEMobility("http://localhost:8081/Namf_Event_Exposure_Notify",
                     correlationID);
 
         }
@@ -180,6 +180,7 @@ public class AMFController extends Functionality {
 
         // Adding unSubCorrelationId into database;
         UUID unSubCorrelationId = UUID.randomUUID();
+        out.println("in-load-level----->> + "+obj.getNotificationTargetAddress() + "::"+obj.getCorrelationId());
         correlationIDList.add(obj.getCorrelationId());
 
         return new ResponseEntity<String>(String.valueOf(unSubCorrelationId), HttpStatus.OK);
@@ -193,12 +194,16 @@ public class AMFController extends Functionality {
         //  list.add();
 
         JSONObject json = new JSONObject(response);
+
         Namf_EventExposure_Subscribe obj = new Namf_EventExposure_Subscribe();
         obj.setCorrelationId(json.getString("correlationID"));
         obj.setNotificationTargetAddress(json.getString("notificationTargetAddress"));
 
         // Adding unSubCorrelationId into database;
         UUID unSubCorrelationId = UUID.randomUUID();
+
+        out.println("in-UE-Mobility----->> + "+obj.getNotificationTargetAddress() + "::"+obj.getCorrelationId());
+
         correlationIDList.add(obj.getCorrelationId());
 
         return new ResponseEntity<String>(String.valueOf(unSubCorrelationId), HttpStatus.OK);
@@ -407,7 +412,7 @@ public class AMFController extends Functionality {
 
         //  out.println("In send Data for UE-Mobility");
 
-        notiTargetAddress = "http://localhost:8081/Namf_EventExposure_Notify";
+        notiTargetAddress = "http://localhost:8081/Namf_Event_Exposure_Notify";
 
 
         // initialize a Random object somewhere; you should only need one

--- a/Simulator/AMF/src/main/java/com/nwdaf/AMF/AmfApplication.java
+++ b/Simulator/AMF/src/main/java/com/nwdaf/AMF/AmfApplication.java
@@ -44,20 +44,27 @@ public class AmfApplication extends Functionality {
 
     public void test(int subList, int eventID) throws Exception {
 
-        //  System.out.println("Subscribers Count - " + subList);
-        int MCC = random.nextInt(900) + 100;
-        // System.out.println("MCC - " + MCC);
-        int MNC = random.nextInt(900) + 100;
-        // System.out.println("MNC - " + MNC);
-        int IMSI = random.nextInt(900000000) + 100000000;
-        // System.out.println("IMSI" + IMSI);
+        AMFController amfController = new AMFController();
+        int MCC;
+        int MNC;
+        int IMSI;
+        String supi;
 
-        String supi = String.valueOf(MCC) + String.valueOf(MNC) + String.valueOf(IMSI);
+
+//        //  System.out.println("Subscribers Count - " + subList);
+//        int MCC = random.nextInt(900) + 100;
+//        // System.out.println("MCC - " + MCC);
+//        int MNC = random.nextInt(900) + 100;
+//        // System.out.println("MNC - " + MNC);
+//        int IMSI = random.nextInt(900000000) + 100000000;
+//        // System.out.println("IMSI" + IMSI);
+
+        //    String supi = String.valueOf(MCC) + String.valueOf(MNC) + String.valueOf(IMSI);
 
         //  System.out.println("SUPI ---- > " + supi);
 
 
-        if (0 == eventID) {
+       /* if (0 == eventID) {
             for (int i = 0; i < subList; i++) {
 
                 // int eventIDvalue = eventIDArray[rand.nextInt(eventIDArray.length)];
@@ -68,7 +75,7 @@ public class AmfApplication extends Functionality {
                         snssaisArray[rand.nextInt(snssaisArray.length)],
                         1,
                         0,
-                        supi,
+                        "NULL",
                         rand.nextInt(30) + 40); /// rand.nextInt( high - low ) + low
 
                 //  System.out.println("Un-sub-URI : " + subId);
@@ -82,11 +89,30 @@ public class AmfApplication extends Functionality {
 
                 unSubURIMap.put(ID, URI);
 
+
+                for (int j = 0; j < amfController.getCorrelationIDList().size(); j++) {
+
+                    amfController.sendData("http://localhost:8081/Nnrf_NFManagement_NFStatusNotify",
+                            amfController.getCorrelationIDList().get(j));
+                    // amfApplication.unsubscribe(subIDList.get(i));
+                }
+
+
                 // subIDList.add(subId);
             }
-        }
+        }*/
         if (5 == eventID) {
             for (int i = 0; i < subList; i++) {
+
+                //  System.out.println("Subscribers Count - " + subList);
+                MCC = random.nextInt(900) + 100;
+                // System.out.println("MCC - " + MCC);
+                MNC = random.nextInt(900) + 100;
+                // System.out.println("MNC - " + MNC);
+                IMSI = random.nextInt(900000000) + 100000000;
+                // System.out.println("IMSI" + IMSI);
+                supi = String.valueOf(MCC) + String.valueOf(MNC) + String.valueOf(IMSI);
+
 
                 // int eventIDvalue = eventIDArray[rand.nextInt(eventIDArray.length)];
                 System.out.println("even-ID-value = " + eventID);
@@ -106,17 +132,114 @@ public class AmfApplication extends Functionality {
                 String URI = subId.substring(0, subId.length() - 37);
                 System.out.println("URI - " + URI);
 
-                //unSubURIMap.put(,ID);
-
                 unSubURIMap.put(ID, URI);
+
+              /*  if (amfController.getCorrelationIDListForUE().size() != 0) {
+                    for (int j = 0; j < amfController.getCorrelationIDListForUE().size(); j++) {
+
+                        System.out.println("Sending data for UE :: correlationListSIze " + amfController.getCorrelationIDListForUE().size());
+                        System.out.println("correlationID  - " + amfController.getCorrelationIDListForUE().get(j));
+                        amfController.sendDataForUEMobility("http://localhost:8081/Namf_EventExposure_Notify",
+                                amfController.getCorrelationIDListForUE().get(j));
+
+
+                    }
+                }*/
+
+
+                System.out.println("URI-map_size ------> " + unSubURIMap.size());
 
                 // subIDList.add(subId);
             }
         }
-        if (3 == eventID) {
+       /* if (3 == eventID) {
             System.out.println("even-ID-value = " + eventID);
             System.out.println("Qos_changes");
-        }
+        }*/
+       /* if (10 == eventID) {
+
+            for (int i = 0; i < subList; i++) {
+
+                String updatedSupi = "NULL";
+
+                //  System.out.println("Subscribers Count - " + subList);
+                MCC = random.nextInt(900) + 100;
+                // System.out.println("MCC - " + MCC);
+                MNC = random.nextInt(900) + 100;
+                // System.out.println("MNC - " + MNC);
+                IMSI = random.nextInt(900000000) + 100000000;
+                // System.out.println("IMSI" + IMSI);
+                supi = String.valueOf(MCC) + String.valueOf(MNC) + String.valueOf(IMSI);
+
+
+                int eventIDvalue = eventIDArray[rand.nextInt(eventIDArray.length)];
+
+                if (0 == eventIDvalue) {
+                    supi = updatedSupi;
+                }
+                if (5 == eventIDvalue) {
+                    updatedSupi = supi;
+                }
+               *//* if (0 == eventIDvalue || 3 == eventIDvalue) {
+                    supi = "NULL";
+                }*//*
+                System.out.println("even-ID-value-from-prop = " + eventID);
+                System.out.println("even-ID-value-from-list = " + eventIDvalue);
+
+                String subId = subscribe(eventIDvalue,
+                        "http://localhost:8082/notify",
+                        snssaisArray[rand.nextInt(snssaisArray.length)],
+                        1,
+                        0,
+                        updatedSupi,
+                        rand.nextInt(30) + 40); /// rand.nextInt( high - low ) + low
+
+                //  System.out.println("Un-sub-URI : " + subId);
+//                System.out.println("Length - " + subId.length());
+                String ID = subId.substring(subId.length() - 36, subId.length());
+//                System.out.println("ID - " + ID);
+                String URI = subId.substring(0, subId.length() - 37);
+//                System.out.println("URI - " + URI);
+
+                //unSubURIMap.put(,ID);
+
+
+                if (0 == eventIDvalue) {
+
+                    if (0 != amfController.getCorrelationIDList().size()) {
+                        for (int j = 0; j < amfController.getCorrelationIDList().size(); j++) {
+                            System.out.println("Sending data for Load-level :: correlationListSIze " + amfController.getCorrelationIDList().size());
+                            System.out.println("correlationID  - " + amfController.getCorrelationIDList().get(j));
+
+                            amfController.sendData("http://localhost:8081/Nnrf_NFManagement_NFStatusNotify",
+                                    amfController.getCorrelationIDList().get(j));
+                        }
+                    }
+
+
+                }
+                if (5 == eventIDvalue) {
+
+                    if (0 != amfController.getCorrelationIDListForUE().size()) {
+                        for (int j = 0; j < amfController.getCorrelationIDListForUE().size(); j++) {
+
+                            System.out.println("Sending data for UE :: correlationListSIze " + amfController.getCorrelationIDListForUE().size());
+                            System.out.println("correlationID  - " + amfController.getCorrelationIDListForUE().get(j));
+                            amfController.sendDataForUEMobility("http://localhost:8081/Namf_EventExposure_Notify",
+                                    amfController.getCorrelationIDListForUE().get(j));
+
+
+                        }
+                    }
+
+                }
+
+
+                // subIDList.add(subId);
+            }
+
+
+        }*/
 
     }
 
@@ -138,7 +261,7 @@ public class AmfApplication extends Functionality {
 
         // amfController.testJSONData();
 
-        amfApplication.test(subListInt, eventIDInt);
+        // amfApplication.test(subListInt, eventIDInt);
 
        /* for (int i = 0; i < amfController.getCorrelationIDList().size(); i++) {
             amfController.sendDataForUEMobility("http://localhost:8081/Namf_EventExposure_Notify",
@@ -153,13 +276,13 @@ public class AmfApplication extends Functionality {
         }*/
 
 
-     /*   while (true) {
+      /*  while (true) {
             //Thread.sleep(5000);
 
-            amfApplication.test(subList);
+            amfApplication.test(subListInt, eventIDInt);
             //  System.out.println("Main correaltionList - " + amfController.getCorrelationIDList().size());
 
-         /*   for (int i = 0; i < amfController.getCorrelationIDList().size(); i++) {
+         *//*   for (int i = 0; i < amfController.getCorrelationIDList().size(); i++) {
                 amfController.sendData("http://localhost:8081/Nnrf_NFManagement_NFStatusNotify",
                         amfController.getCorrelationIDList().get(i));
                 // amfApplication.unsubscribe(subIDList.get(i));
@@ -175,10 +298,10 @@ public class AmfApplication extends Functionality {
                             amfController.getCorrelationIDList().get(i));
                 }
 
-            }
+            }*//*
 
             Thread.sleep(20 * 1000);
-        } */
+        }*/
 
 
         // AMFController amfController = new AMFController();

--- a/Simulator/AMF/src/main/java/com/nwdaf/AMF/AmfApplication.java
+++ b/Simulator/AMF/src/main/java/com/nwdaf/AMF/AmfApplication.java
@@ -42,7 +42,7 @@ public class AmfApplication extends Functionality {
     Random random = new Random();
 
 
-    public void test(int subList) throws Exception {
+    public void test(int subList, int eventID) throws Exception {
 
         //  System.out.println("Subscribers Count - " + subList);
         int MCC = random.nextInt(900) + 100;
@@ -57,32 +57,67 @@ public class AmfApplication extends Functionality {
         //  System.out.println("SUPI ---- > " + supi);
 
 
-        for (int i = 0; i < subList; i++) {
+        if (0 == eventID) {
+            for (int i = 0; i < subList; i++) {
 
-            int eventIDvalue = eventIDArray[rand.nextInt(eventIDArray.length)];
-            System.out.println("even-ID-value = " + eventIDvalue);
+                // int eventIDvalue = eventIDArray[rand.nextInt(eventIDArray.length)];
+                System.out.println("even-ID-value = " + eventID);
 
-            String subId = subscribe(5,
-                    "http://localhost:8082/notify",
-                    snssaisArray[rand.nextInt(snssaisArray.length)],
-                    1,
-                    0,
-                    supi,
-                    rand.nextInt(30) + 40); /// rand.nextInt( high - low ) + low
+                String subId = subscribe(0,
+                        "http://localhost:8082/notify",
+                        snssaisArray[rand.nextInt(snssaisArray.length)],
+                        1,
+                        0,
+                        supi,
+                        rand.nextInt(30) + 40); /// rand.nextInt( high - low ) + low
 
-            //  System.out.println("Un-sub-URI : " + subId);
-            System.out.println("Length - " + subId.length());
-            String ID = subId.substring(subId.length() - 36, subId.length());
-            System.out.println("ID - " + ID);
-            String URI = subId.substring(0, subId.length() - 37);
-            System.out.println("URI - " + URI);
+                //  System.out.println("Un-sub-URI : " + subId);
+                System.out.println("Length - " + subId.length());
+                String ID = subId.substring(subId.length() - 36, subId.length());
+                System.out.println("ID - " + ID);
+                String URI = subId.substring(0, subId.length() - 37);
+                System.out.println("URI - " + URI);
 
-            //unSubURIMap.put(,ID);
+                //unSubURIMap.put(,ID);
 
-            unSubURIMap.put(ID, URI);
+                unSubURIMap.put(ID, URI);
 
-            // subIDList.add(subId);
+                // subIDList.add(subId);
+            }
         }
+        if (5 == eventID) {
+            for (int i = 0; i < subList; i++) {
+
+                // int eventIDvalue = eventIDArray[rand.nextInt(eventIDArray.length)];
+                System.out.println("even-ID-value = " + eventID);
+
+                String subId = subscribe(5,
+                        "http://localhost:8082/notify",
+                        snssaisArray[rand.nextInt(snssaisArray.length)],
+                        1,
+                        0,
+                        supi,
+                        rand.nextInt(30) + 40); /// rand.nextInt( high - low ) + low
+
+                //  System.out.println("Un-sub-URI : " + subId);
+                System.out.println("Length - " + subId.length());
+                String ID = subId.substring(subId.length() - 36, subId.length());
+                System.out.println("ID - " + ID);
+                String URI = subId.substring(0, subId.length() - 37);
+                System.out.println("URI - " + URI);
+
+                //unSubURIMap.put(,ID);
+
+                unSubURIMap.put(ID, URI);
+
+                // subIDList.add(subId);
+            }
+        }
+        if (3 == eventID) {
+            System.out.println("even-ID-value = " + eventID);
+            System.out.println("Qos_changes");
+        }
+
     }
 
 
@@ -94,15 +129,16 @@ public class AmfApplication extends Functionality {
 
         // Reading subscriber list From file
         ApplicationPropertiesValue properties = new ApplicationPropertiesValue();
-        String subcout = properties.getPropValues();
+        List<String> propValuesList = properties.getPropValues();
 
-        int subList = Integer.parseInt(subcout);
+        int subListInt = Integer.parseInt(propValuesList.get(0));
+        int eventIDInt = Integer.parseInt(propValuesList.get(1));
 
         AmfApplication amfApplication = new AmfApplication();
 
         // amfController.testJSONData();
 
-        //  amfApplication.test(subList);
+        amfApplication.test(subListInt, eventIDInt);
 
        /* for (int i = 0; i < amfController.getCorrelationIDList().size(); i++) {
             amfController.sendDataForUEMobility("http://localhost:8081/Namf_EventExposure_Notify",

--- a/Simulator/AMF/src/main/java/com/nwdaf/AMF/AmfApplication.java
+++ b/Simulator/AMF/src/main/java/com/nwdaf/AMF/AmfApplication.java
@@ -79,7 +79,7 @@ public class AmfApplication extends Functionality {
 
             //unSubURIMap.put(,ID);
 
-            unSubURIMap.put(ID,URI);
+            unSubURIMap.put(ID, URI);
 
             // subIDList.add(subId);
         }
@@ -117,7 +117,7 @@ public class AmfApplication extends Functionality {
         }*/
 
 
-        while (true) {
+     /*   while (true) {
             //Thread.sleep(5000);
 
             amfApplication.test(subList);
@@ -127,7 +127,7 @@ public class AmfApplication extends Functionality {
                 amfController.sendData("http://localhost:8081/Nnrf_NFManagement_NFStatusNotify",
                         amfController.getCorrelationIDList().get(i));
                 // amfApplication.unsubscribe(subIDList.get(i));
-            }*/
+            }
 
             for (int i = 0; i < amfController.getCorrelationIDList().size(); i++) {
                 amfController.sendDataForUEMobility("http://localhost:8081/Namf_EventExposure_Notify",
@@ -142,8 +142,7 @@ public class AmfApplication extends Functionality {
             }
 
             Thread.sleep(20 * 1000);
-        }
-
+        } */
 
 
         // AMFController amfController = new AMFController();

--- a/Simulator/AMF/src/main/java/com/nwdaf/AMF/ApplicationPropertiesValue.java
+++ b/Simulator/AMF/src/main/java/com/nwdaf/AMF/ApplicationPropertiesValue.java
@@ -8,7 +8,9 @@ package com.nwdaf.AMF;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
 
 
@@ -17,7 +19,9 @@ public class ApplicationPropertiesValue {
     String result = "";
     InputStream inputStream;
 
-    public String getPropValues() throws IOException {
+    public List<String> getPropValues() throws IOException {
+
+        List<String> propList = new ArrayList<>();
 
         try {
             Properties prop = new Properties();
@@ -35,10 +39,15 @@ public class ApplicationPropertiesValue {
 
             // get the property value and print it out
             String subList = prop.getProperty("spring.subscriber.count");
+            String eventVal = prop.getProperty("spring.event.value");
+
             // String company1 = prop.getProperty("company1");
             //String company2 = prop.getProperty("company2");
             //String company3 = prop.getProperty("company3");
 
+
+            propList.add(subList);
+            propList.add(eventVal);
 
             result = subList;
 
@@ -47,6 +56,6 @@ public class ApplicationPropertiesValue {
         } finally {
             inputStream.close();
         }
-        return result;
+        return propList;
     }
 }

--- a/Simulator/AMF/src/main/resources/application.properties
+++ b/Simulator/AMF/src/main/resources/application.properties
@@ -6,6 +6,8 @@ spring.datasource.password=ThePassword
 
 spring.subscriber.count=2
 
+spring.event.value=3
+
 logging.pattern.console=
 spring.main.banner-mode=off
 #logging.file=C:/Users/Sadaf/Desktop/nwdaf28feb/nwdaf/Simulator/AMF/AmfApplicationLog.log

--- a/Simulator/AMF/src/main/resources/application.properties
+++ b/Simulator/AMF/src/main/resources/application.properties
@@ -4,9 +4,9 @@ spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/NWDAF
 spring.datasource.username=springuser
 spring.datasource.password=ThePassword
 
-spring.subscriber.count=2
+spring.subscriber.count=200
 
-spring.event.value=3
+spring.event.value=5
 
 logging.pattern.console=
 spring.main.banner-mode=off

--- a/Simulator/AMF/src/main/resources/application.properties
+++ b/Simulator/AMF/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 server.port=8082
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/NWDAF
-spring.datasource.username=
-spring.datasource.password=
+spring.datasource.username=springuser
+spring.datasource.password=ThePassword
 
-spring.subscriber.count=100000
+spring.subscriber.count=2
 
 logging.pattern.console=
 spring.main.banner-mode=off


### PR DESCRIPTION
- JSON final notification fixed.
Previously, the JSON array was containing notification for all events. Now I have separated this thing. If NF is subscribing for only for load level then it will only receive a load-level notification.

Changes in SIMULATOR - 

- MAP added for unsubscription.
- event-id can be read via applications.properties

- testing can be done based on event id 
if event id =0 --> load-level
if event id=5 --> UE-mobility
if event id =10 --> load-level OR UE-mobility